### PR TITLE
fix search

### DIFF
--- a/app.py
+++ b/app.py
@@ -121,20 +121,20 @@ def query():
     query = request.args['searchbar'] # query text
     albumMatches = albumPage.get_similar_albums(conn,query)
     songMatches = songPage.get_similar_songs(conn,query)
-    users = userpage.search_user(conn, query)
+    userMatches = userpage.search_user(conn, query)
 
     # no matches
-    if len(albumMatches) == 0 and len(songMatches) == 0 and not users:
+    if not albumMatches and not songMatches and not users:
         return render_template('notFound.html', type='Nothing',
         page_title="No matches")
     # one album matches
-    elif len(albumMatches) == 1 and len(songMatches) == 0 and not users:
+    elif len(albumMatches) == 1 and not songMatches and not users:
         return redirect(url_for('album', aid=albumMatches[0]['album_id']))
     # one song matches
     elif len(songMatches) == 1 and not users:
         return redirect(url_for('song', sid=songMatches[0]['song_id']))
     
-    elif users:
+    elif userMatches and not songMatches and not albumMatches:
         return render_template("search.html", users = users)
 
     # multiple matches
@@ -150,8 +150,13 @@ def query():
             songID = songDict['song_id']
             songs.append(songPage.get_song(conn, songID))
 
+        users = []
+        for userDict in userMatches:
+            userID = userDict['user_id']
+            users.append(userpage.get_user_id(conn, userID))
+
         return render_template('multiple.html', 
-            albums=albums, songs=songs,
+            albums=albums, songs=songs, users=users,
             name = query,
             page_title="Mutliple Results Found")
 

--- a/app.py
+++ b/app.py
@@ -36,6 +36,7 @@ def search():
     print(users)
     if users:
         return render_template("search.html", users = users)
+
 '''
 Displays name, genre, and creator for a playlist, along with all the
 songs that have been added to the playlist
@@ -89,7 +90,7 @@ def album(aid):
 
 ''' 
 This is the route for song lookups. It renders a template 
-with information about the artist and which album it appears on.
+with the artist's name and the title of the album on which album it appears.
 
 :param sid: a unique song id from the coda_song table
 :returns: not found page if song does not exist in the database
@@ -108,26 +109,34 @@ def song(sid):
             song=song_info,
             page_title='Song | ' + song_info['song_title'])
 
-''' Renders the template for the user's search. '''
+'''
+Renders the template for the user's search.
+:returns: the item's (album, song, or user) individual page if there is
+          exactly one match
+          otherwise, lists out all matches with links to their individual pages.
+'''
 @app.route('/query/', methods=['GET'])
 def query():
     conn = dbi.connect()
-    query = request.args['query'] # query text
-
+    query = request.args['searchbar'] # query text
     albumMatches = albumPage.get_similar_albums(conn,query)
     songMatches = songPage.get_similar_songs(conn,query)
+    users = userpage.search_user(conn, query)
 
     # no matches
-    if len(albumMatches) == 0 and len(songMatches) == 0:
-        return render_template('notFound.html', type='nothing',
-        page_title="Album Not Found")
+    if len(albumMatches) == 0 and len(songMatches) == 0 and not users:
+        return render_template('notFound.html', type='Nothing',
+        page_title="No matches")
     # one album matches
-    elif len(albumMatches) == 1 and len(songMatches) == 0:
+    elif len(albumMatches) == 1 and len(songMatches) == 0 and not users:
         return redirect(url_for('album', aid=albumMatches[0]['album_id']))
     # one song matches
-    elif len(songMatches) == 1:
+    elif len(songMatches) == 1 and not users:
         return redirect(url_for('song', sid=songMatches[0]['song_id']))
     
+    elif users:
+        return render_template("search.html", users = users)
+
     # multiple matches
     else:
         # get the ids for each album and song that matches the query

--- a/templates/album.html
+++ b/templates/album.html
@@ -1,7 +1,6 @@
 <!-- Author: Audrea Huang - Fall T1 2020 -->
-<!-- Template for describing information about an album. 
-Will display the person's name, birthday, who added them, 
-as well as any movies they have acted in. -->
+<!-- Template for describing information about an album.
+Lists the album title, artist, release year, and songs. -->
 {% extends "base.html" %}
 
 {% block main_content %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,6 +5,7 @@
     <meta name=author content="">
     <title>{{ page_title }}</title>
     <link rel='stylesheet' href="{{url_for('static', filename = 'style.css')}}">
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans&display=swap" rel="stylesheet">
     <!-- {% block head_stuff %} {% endblock %} -->
 </head>
 <body>
@@ -21,7 +22,7 @@
             
 
 {% block nav %}
-<form class="search" method="GET" action= "/search/">
+<form class="search" method="GET" action= "/query/">
   <p><label>search: <input type="text" name="searchbar"></label>
   <input type="submit" value="search"></p>
 </form>

--- a/templates/multiple.html
+++ b/templates/multiple.html
@@ -1,27 +1,26 @@
-<!-- Authors: Audrea Huang - Fall T1 2020 -->
+<!-- Author: Audrea Huang - Fall T1 2020 -->
 <!-- This is the html template for saerch queries that result in 
 multiple matches.  -->
 {% extends "base.html" %}
 
 {% block main_content %}
 
-<p>
-    <!-- Case 1: If the user is searching for a person -->
     
-    Albums matching {{name}}
+<h3> Albums matching {{name}} </h3>
+
     <ul>
         {% for album in albums %} 
             <li><a href="{{ url_for('album', aid=album.album_id) }}">{{album.album_title}}</a></li>
         {% endfor %}
     </ul>
 
-    Songs matching {{name}}
+    
+<h3> Songs matching {{name}} </h3>
     <ul>
         {% for song in songs %} 
             <li><a href="{{ url_for('song', sid=song.song_id) }}">{{song.song_title}}</a></li>
         {% endfor %}
     </ul>
     
-</p>
 
 {% endblock %}

--- a/templates/multiple.html
+++ b/templates/multiple.html
@@ -9,8 +9,8 @@ multiple matches.  -->
 <h3> Albums matching {{name}} </h3>
 
     <ul>
-        {% for album in albums %} 
-            <li><a href="{{ url_for('album', aid=album.album_id) }}">{{album.album_title}}</a></li>
+        {% for album in albums %}  
+             <li><a href="{{ url_for('album', aid=album.album_id) }}">{{album.album_title}}</a></li>
         {% endfor %}
     </ul>
 
@@ -22,5 +22,12 @@ multiple matches.  -->
         {% endfor %}
     </ul>
     
+<h3> Users matching {{name}} </h3>
+    <ul>
+        {% for user in users %}
+            <li><a href="{{ url_for('user', user_id=user.user_id) }}">
+		{{user.user_name}}</a></li>
+        {% endfor %}
+    </ul>
 
 {% endblock %}

--- a/templates/notFound.html
+++ b/templates/notFound.html
@@ -1,4 +1,4 @@
-<!-- Authors: Christine Lam & Audrea Huang - Fall T1 2020 -->
+<!-- Author: Audrea Huang - Fall T1 2020 -->
 <!-- Page that renders if no result is found. -->
 {% extends "base.html" %}
 

--- a/templates/song.html
+++ b/templates/song.html
@@ -1,7 +1,7 @@
 <!-- Author: Audrea Huang - Fall T1 2020 -->
-<!-- Template for describing information about an album. 
-Will display the person's name, birthday, who added them, 
-as well as any movies they have acted in. -->
+<!-- Template for describing information about a song. 
+Displays the title, artist, release year, which album it appears on,
+and who added the song to the database. -->
 {% extends "base.html" %}
 
 {% block main_content %}


### PR DESCRIPTION
If the user's query matches exactly one album or song, route directly to that page.
If multiple items in the database match the query, display a list of all albums, songs, and users matching.
