### PR TITLE
remove genre duplicates

### DIFF
--- a/app.py
+++ b/app.py
@@ -16,7 +16,7 @@ import cs304dbi as dbi
 
 # import cs304dbi_sqlite3 as dbi
 
-import random, playlist, albumPage, songPage, userpage
+import random, playlist, albumPage, songPage, userpage, re
 
 app.secret_key = 'your secret here'
 # replace that with a random key
@@ -31,8 +31,13 @@ app.config['TRAP_BAD_REQUEST_ERRORS'] = True
 @app.route('/')
 def index():
     conn = dbi.connect()
-    genres = songPage.get_genres(conn)
-    return render_template('main.html',title='Home',genres=genres)
+    # might have multiple genres for one song
+    genresDB = songPage.get_genres(conn) 
+    genres = []
+    for genre in genresDB:
+        # separate genres and strip any leading/trailing whitespace
+        genres += [oneGenre.strip().lower() for oneGenre in re.split('\||,', genre)]
+    return render_template('main.html',title='Home',genres=sorted(genres))
 
 '''
 Displays name, genre, and creator for a playlist, along with all the

--- a/songPage.py
+++ b/songPage.py
@@ -55,15 +55,16 @@ def get_genres(conn):
 Gets all the songs of a given genre to organize the explore page.
 :param genre: one genre of interest
 :param conn: connection to database
-:returns: all the song ids, titles, artists, and albums grouped by genre
+:returns: all the song ids, titles, artists, and albums for that genre
 '''
 def songs_by_genre(conn, genre):
     curs = dbi.dict_cursor(conn)
+    genre = '%' + genre + '%'
     curs.execute('''select song_id, song_title, 
         artist_name, album_title from coda_song
         join coda_album using(album_id)
         join coda_artist using(artist_id)
-        where coda_song.genre = %s''', [genre])
+        where coda_song.genre like %s''', [genre])
     genreDictList = curs.fetchall()
     return genreDictList
 
@@ -80,6 +81,6 @@ if __name__ == '__main__':
     # genres = get_genres(conn)
     # print(genres)
 
-    countrySongs = songs_by_genre(conn, 'Country')
+    countrySongs = songs_by_genre(conn, 'Christmas')
     print(countrySongs)
     


### PR DESCRIPTION
Some songs and playlists have listed multiple genres (such as 'Christmas|a cappella'), so the explore page represented both of these as one separate genre. This PR separates those and allows a song/playlist to appear in the results for both the 'Christmas' and 'a cappella' genres.