### PR TITLE
condense queries from loop

### DIFF
--- a/albumPage.py
+++ b/albumPage.py
@@ -25,6 +25,23 @@ def get_album(conn, aid):
         where album_id = %s''', [aid])
     return curs.fetchone()
 
+def multiple_albums(conn, aid_list):
+    ''' 
+    Get a list of all the albums with ids in the provided list.
+    This prevents us from needing to execute queries in a loop.
+
+    :param conn: connection to database
+    :param aid_list: int[] with ids for specified albums
+    :returns: a list of dictionaries with album information for
+        the requested albums
+    '''
+    curs = dbi.dict_cursor(conn)
+    curs.execute('''select album_id, album_title, artist_name,
+        release_year, artist_id from coda_album
+        join coda_artist using(artist_id)
+        where album_id in %s''', [aid_list])
+    return curs.fetchall()
+
 def get_songs(conn, aid):
     ''' 
     Get the songs on this album.

--- a/app.py
+++ b/app.py
@@ -213,7 +213,8 @@ def playlistPage(pid):
                 playlist.deletePlaylist(conn,pid)
                 flash(oldName + ' deleted successfully')
                 return redirect(url_for('user', uid = uid))
-    else:
+    # what is the point of this branch
+    else: # HUH how do we get playlistInfo, nestedSongs, and createdby
         return render_template('playlist.html', 
                             playlistInfo=playlistInfo, 
                             songs=nestedSongs, 
@@ -556,43 +557,46 @@ def query():
         artist = artistMatches[0]
         artistAlbums = artistPage.get_artist_albums(conn, artist['artist_id'])
         return render_template("artist.html", artist=artist, 
-            albumList=artistAlbums, page_title=artist['artist_name'], user_id=user_id)
+            albumList=artistAlbums, page_title=artist['artist_name'], 
+            user_id=user_id)
 
     # multiple matches
     else:
-        # get the ids for each album and song that matches the query
+        # get the ids for each album that matches the query
         albums = []
-        for albumDict in albumMatches:
-            albumID = albumDict['album_id']
-            albums.append(albumPage.get_album(conn, albumID))  
+        album_list = [albumDict['album_id'] for albumDict in albumMatches]
+        if len(album_list) > 0:
+            # only execute if there exist album ids for which to extract info
+            albums = albumPage.multiple_albums(conn, album_list)
 
         # extract information for each matching song
         songs = []
-        for songDict in songMatches:
-            songID = songDict['song_id']
-            songs.append(songPage.get_song(conn, songID))
+        sid_list = [songDict['song_id'] for songDict in songMatches]
+        if len(sid_list) > 0:
+            songs = songPage.multiple_songs(conn, sid_list)
 
         # extract information for each matching user
         users = []
-        for userDict in userMatches:
-            userID = userDict['user_id']
-            users.append(userpage.get_user_from_id(conn, userID))
-
+        uid_list = [userDict['user_id'] for userDict in userMatches]
+        if len(uid_list) > 0:
+            users = userpage.multiple_users(conn, uid_list)
+        
         # extract information for each matching playlist
         playlists = []
-        for playlistDict in playlistMatches:
-            playlistID = playlistDict['playlist_id']
-            playlists.append(playlist.get_playlist_info(conn, playlistID))
+        pid_list = [playlistDict['playlist_id'] for playlistDict
+            in playlistMatches]
+        if len(pid_list) > 0:
+            playlists = playlist.multiple_playlists(conn, pid_list)
 
         # extract information for each matching artist
         artists = []
-        for artistDict in artistMatches:
-            artistID = artistDict['artist_id']
-            artists.append(artistPage.get_artist(conn, artistID))
+        artist_list = [artistDict['artist_id'] for artistDict in artistMatches]
+        if len(artist_list) > 0:
+            artists = artistPage.multiple_artists(conn, artist_list)
 
         return render_template('multiple.html', 
             albums=albums, songs=songs, users=users,
-            playlists=playlists, name = query, artists=artists,
+            playlists=playlists, artists=artists, name=query, 
             page_title="Mutliple Results Found", user_id=user_id)
 
 

--- a/artistPage.py
+++ b/artistPage.py
@@ -56,3 +56,16 @@ def get_artist(conn, artist_id):
     curs.execute('''select * from coda_artist where artist_id = %s''', 
         [artist_id])
     return curs.fetchone()
+
+def multiple_artists(conn, aid_list):
+    '''
+    Retrieves information for multiple artists.
+
+    :param conn: connection to database
+    :param aid_list: int[] representing unique artist ids
+    :returns: a list of dictionaries containing the artists' information
+    '''
+    curs = dbi.dict_cursor(conn)
+    curs.execute('''select * from coda_artist where artist_id in %s''', 
+        [aid_list])
+    return curs.fetchall()

--- a/playlist.py
+++ b/playlist.py
@@ -24,6 +24,26 @@ def get_playlist_info(conn,pid):
     curs.execute(sql,[pid])
     return curs.fetchone()
 
+def multiple_playlists(conn,pid_list):
+    """
+    Given a connection object and list of playlist ids, gets the name, 
+    genre, and creator of those playlists
+
+    :param conn: connection to database
+    :param pid_list: integer list indicating unique playlist ids
+    :returns: a list of dictionaries containing the playlist's name, genre, id,
+        and the id and name of the user who created it for each specified
+        playlist
+    """
+    curs = dbi.dict_cursor(conn)
+    sql = '''select playlist_name, playlist_genre, display_name, playlist_id, 
+            created_by from coda_playlist 
+            inner join coda_user on 
+                (coda_user.user_id = coda_playlist.created_by)
+            where playlist_id in %s'''
+    curs.execute(sql,[pid_list])
+    return curs.fetchall()
+
 def get_all_playlists_by_user(conn,username):
     """
     Given a connection object and a uid, returns all playlists in the 

--- a/songPage.py
+++ b/songPage.py
@@ -28,6 +28,27 @@ def get_song(conn, sid):
         where song_id = %s''', [sid])
     return curs.fetchone()
 
+def multiple_songs(conn, sid_list):
+    '''
+    Get a list of all the albums with ids in the provided list.
+    This prevents us from needing to execute queries in a loop.
+
+    :param conn: connection to database
+    :param aid_list: int[] with ids for specified songs
+    :returns: a list of dictionaries with song information for
+        the requested song ids
+    '''
+    curs = dbi.dict_cursor(conn)
+    curs.execute('''select song_title, genre, display_name,
+        artist_name, release_year, album_title, song_id,
+        artist_id, album_id, user_id
+        from coda_song
+        join coda_album using(album_id)
+        join coda_artist using(artist_id)
+        join coda_user on coda_user.user_id = coda_song.added_by
+        where song_id in %s''', [sid_list])
+    return curs.fetchall()
+
 def get_similar_songs(conn, text):
     '''
     Gets the songs whose names are similar to the user's query

--- a/templates/multiple.html
+++ b/templates/multiple.html
@@ -6,22 +6,25 @@
 
 {% block main_content %}
 
-    
+{% if songs|length > 0 %}
 <h3> Songs matching {{name}} </h3>
-    <ul>
-        {% for song in songs %} 
-            <li><a href="{{ url_for('song', sid=song.song_id) }}">{{song.song_title}}</a></li>
-        {% endfor %}
-    </ul>
-    
+<ul>
+    {% for song in songs %} 
+        <li><a href="{{ url_for('song', sid=song.song_id) }}">{{song.song_title}}</a></li>
+    {% endfor %}
+</ul>
+{% endif %}
+
+{% if albums|length > 0 %}
 <h3> Albums matching {{name}} </h3>
+<ul>
+    {% for album in albums %}  
+            <li><a href="{{ url_for('album', aid=album.album_id) }}">{{album.album_title}}</a></li>
+    {% endfor %}
+</ul>
+{% endif %}
 
-    <ul>
-        {% for album in albums %}  
-             <li><a href="{{ url_for('album', aid=album.album_id) }}">{{album.album_title}}</a></li>
-        {% endfor %}
-    </ul>
-
+{% if playlists|length > 0 %}
 <h3> Playlists matching {{name}} </h3>
 <ul>
     {% for playlist in playlists %}
@@ -29,20 +32,26 @@
     {{playlist.playlist_name}}</a></li>
     {% endfor %}
 </ul>
+{% endif %}
     
+{% if users|length > 0 %}
 <h3> Users matching {{name}} </h3>
-    <ul>
-        {% for user in users %}
-            <li><a href="{{ url_for('user', uid=user.user_id) }}">
-		{{user.display_name}}</a></li>
-        {% endfor %}
-    </ul>
+<ul>
+    {% for user in users %}
+        <li><a href="{{ url_for('user', uid=user.user_id) }}">
+    {{user.display_name}}</a></li>
+    {% endfor %}
+</ul>
+{% endif %}
 
+{% if artists|length > 0 %}
 <h3> Artists matching {{name}} </h3>
-    <ul>
-        {% for artist in artists %}
-            <li><a href="{{ url_for('artist', aid=artist.artist_id) }}">
-        {{artist.artist_name}}</a></li>
-        {% endfor %}
-    </ul>
+<ul>
+    {% for artist in artists %}
+        <li><a href="{{ url_for('artist', aid=artist.artist_id) }}">
+    {{artist.artist_name}}</a></li>
+    {% endfor %}
+</ul>
+{% endif %}
+
 {% endblock %}

--- a/userpage.py
+++ b/userpage.py
@@ -37,6 +37,18 @@ def get_user_from_id(conn, user_id):
     curs.execute('''select * from coda_user where user_id = %s''', [user_id])
     return curs.fetchone()
 
+def multiple_users(conn, uid_list):
+    '''
+    Retrieves user information given a list of ids.
+    :param conn: connection to database
+    :param uid_list: int[] with unique ids for specified users
+    :returns: a list of dictionaries with those users' ids, display names, 
+        and CAS usernames
+    '''
+    curs = dbi.dict_cursor(conn)
+    curs.execute('''select * from coda_user where user_id in %s''', [uid_list])
+    return curs.fetchall()
+
 def get_userid_from_username(conn, username):
     '''
     Retrieves user id where the username is specific to CAS log in.


### PR DESCRIPTION
Previously had queries in a loop:
 ```
albums = []
        for albumDict in albumMatches:
            albumID = albumDict['album_id']
            albums.append(albumPage.get_album(conn, albumID)) 
```
which meant that if N albums matched, we did N queries 

This PR condenses them into a single query (for artist, song, user, playlist, and album matches) by providing multiple IDs at once
Removes headers for content types if there are no matches for that category (artist, song, etc.)
